### PR TITLE
Fixed invalid YAML (SF 3.4+)

### DIFF
--- a/Resources/config/services/managers.yml
+++ b/Resources/config/services/managers.yml
@@ -7,9 +7,9 @@ services:
     ecentria.api.domain_message.manager:
         class: %ecentria.api.domain_message.class%
         arguments:
-            - @event_dispatcher
+            - '@event_dispatcher'
 
     ecentria.api.domain_message_consumer.service:
         class: %ecentria.api.domain_message_consumer.class%
         arguments:
-            - @ecentria.api.domain_message.manager
+            - '@ecentria.api.domain_message.manager'


### PR DESCRIPTION
The reserved indicator "@" cannot start a plain scalar; you need to quote the scalar